### PR TITLE
Refactor location handling to prevent data loss on reload

### DIFF
--- a/SunburnApp/script.js
+++ b/SunburnApp/script.js
@@ -7,22 +7,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const sunIcon = document.getElementById('sun-icon');
     const safetyText = document.getElementById('safety-text');
     const lastUpdatedSpan = document.getElementById('last-updated');
-    const lastLocation = localStorage.getItem('lastLocation');
+    const lastLocationData = localStorage.getItem('lastLocation');
     const suggestionsContainer = document.createElement('div');
     suggestionsContainer.id = 'suggestions-container';
     locationInput.parentNode.insertBefore(suggestionsContainer, locationInput.nextSibling);
 
     // Auto-load weather for last location
-    if (lastLocation) {
-        locationInput.value = lastLocation;
-        getWeatherByCity(lastLocation);
+    if (lastLocationData) {
+        const location = JSON.parse(lastLocationData);
+        locationInput.value = location.name;
+        getWeatherByCoords(location.latitude, location.longitude);
     }
 
     checkUVBtn.addEventListener('click', () => {
-        const location = locationInput.value;
-        if (location) {
-            localStorage.setItem('lastLocation', location);
-            getWeatherByCity(location);
+        const locationName = locationInput.value;
+        if (locationName) {
+            getWeatherByCity(locationName);
         } else {
             alert('Please enter a location.');
         }
@@ -33,9 +33,23 @@ document.addEventListener('DOMContentLoaded', () => {
             navigator.geolocation.getCurrentPosition(position => {
                 const lat = position.coords.latitude;
                 const lon = position.coords.longitude;
-                locationInput.value = "Current Location";
-                localStorage.removeItem('lastLocation');
-                getWeatherByCoords(lat, lon);
+                // Fetch location name from coordinates
+                fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        const locationName = data.display_name || "Current Location";
+                        locationInput.value = locationName;
+                        const location = { name: locationName, latitude: lat, longitude: lon };
+                        localStorage.setItem('lastLocation', JSON.stringify(location));
+                        getWeatherByCoords(lat, lon);
+                    })
+                    .catch(() => {
+                         // Fallback if reverse geocoding fails
+                        locationInput.value = "Current Location";
+                        const location = { name: "Current Location", latitude: lat, longitude: lon };
+                        localStorage.setItem('lastLocation', JSON.stringify(location));
+                        getWeatherByCoords(lat, lon);
+                    });
             }, () => {
                 alert('Unable to retrieve your location.');
             });
@@ -62,8 +76,13 @@ document.addEventListener('DOMContentLoaded', () => {
                         const locationName = `${location.name}, ${location.admin1 || ''} ${location.country_code}`;
                         suggestionDiv.textContent = locationName;
                         suggestionDiv.onclick = () => {
+                            const locationData = {
+                                name: locationName,
+                                latitude: location.latitude,
+                                longitude: location.longitude
+                            };
                             locationInput.value = locationName;
-                            localStorage.setItem('lastLocation', locationName);
+                            localStorage.setItem('lastLocation', JSON.stringify(locationData));
                             suggestionsContainer.innerHTML = '';
                             getWeatherByCoords(location.latitude, location.longitude);
                         };
@@ -78,8 +97,15 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(response => response.json())
             .then(data => {
                 if (data.results && data.results.length > 0) {
-                    const location = data.results[0];
-                    getWeatherByCoords(location.latitude, location.longitude);
+                    const locationResult = data.results[0];
+                    const locationData = {
+                        name: `${locationResult.name}, ${locationResult.admin1 || ''} ${locationResult.country_code}`,
+                        latitude: locationResult.latitude,
+                        longitude: locationResult.longitude
+                    };
+                    localStorage.setItem('lastLocation', JSON.stringify(locationData));
+                    locationInput.value = locationData.name;
+                    getWeatherByCoords(locationResult.latitude, locationResult.longitude);
                 } else {
                     alert('Could not find location. Please try again.');
                 }


### PR DESCRIPTION
This commit fixes a bug where the user's last location was not reliably restored in the Pavement and Sunburn applications.

Previously, only the location name (a string) was stored in `localStorage`. On page load, the application would attempt to geocode this string to retrieve the necessary coordinates for an API call. This geocoding step was fragile and would often fail, forcing the user to re-enter their location.

The solution is to store the entire location object—including the name, latitude, and longitude—as a JSON string in `localStorage`. On page load, the application now parses this object and uses the stored coordinates directly to fetch weather data, bypassing the unreliable geocoding lookup. This ensures that the user's location is correctly and consistently restored across sessions.

The following changes were made:
- Modified `PavementTemp/script.js` and `SunburnApp/script.js` to save and retrieve a location object from `localStorage`.
- Updated event handlers for search, geolocation, and suggestions to handle the new data structure.
- Added reverse geocoding to provide a location name when the user selects "Use My Location".