### PR TITLE
feat(xenophile): Implement H-Tree view, skill leveling, and more

### DIFF
--- a/Xenophile/README.md
+++ b/Xenophile/README.md
@@ -19,11 +19,11 @@ Xenophile is a tool that allows you to create skills and link them together in a
 ## Future Ideas (To-Do List)
 
 - [x] Advanced graphical visualization of the skill tree.
-- [ ] **Skill Leveling System:** Implement a 0-5 leveling system for each skill and faculty to track user proficiency.
-- [ ] **Prerequisite Levels:** Allow specifying the required level of a prerequisite to unlock Level 1 of a new skill (e.g., "Palm Basketball (Level 3)" is needed for "Dunk (Level 1)").
-- [ ] **Detailed Level Descriptions:** Add fields in the creation/edit modal for descriptions for each of the 5 proficiency levels.
+- [x] **Skill Leveling System:** Implement a 0-5 leveling system for each skill and faculty to track user proficiency. (Done 2025-10-02)
+- [x] **Prerequisite Levels:** Allow specifying the required level of a prerequisite to unlock Level 1 of a new skill (e.g., "Palm Basketball (Level 3)" is needed for "Dunk (Level 1)"). (Done 2025-10-02)
+- [x] **Detailed Level Descriptions:** Add fields in the creation/edit modal for descriptions for each of the 5 proficiency levels. (Done 2025-10-02)
 - [ ] **"Quick Add" Prerequisite:** Add a '+' button next to items in the tree view to open the creation modal with that item pre-populated as a prerequisite.
-- [ ] **Embedded Links:** Create an easy way to add and display hyperlinks (e.g., to YouTube tutorials or articles) within skill descriptions.
+- [x] **Embedded Links:** Create an easy way to add and display hyperlinks (e.g., to YouTube tutorials or articles) within skill descriptions. (Done 2025-10-02)
 - [ ] **Skill "Pass-Off" System:** Develop a mechanism or checklist to test if a user has learned a skill to a certain level.
 - [ ] Ability to export/import skill trees.
 - [ ] A "discovery" mode where you can only see skills you have the prerequisites for.
@@ -57,6 +57,14 @@ Here are a few technical suggestions to help bring the vision to life:
 ## Changelog
 
 **2025-10-02:**
+- **Horizontal & Vertical Tree Views:** The tree view has been split into two distinct modes: a classic top-down "V-Tree" and a new left-to-right "H-Tree" for alternative visualization.
+- **Skill Leveling System:** A comprehensive 0-5 leveling system has been implemented. Users can now track their proficiency for each skill and faculty directly on the item card.
+- **Prerequisite Levels:** When creating or editing a skill, users can now specify the required level (1-5) of a prerequisite needed to unlock the new skill.
+- **Detailed Level Descriptions:** The "Add/Edit" modal now features a tabbed interface allowing for unique descriptions to be added for each of the 5 proficiency levels. The relevant description is displayed on the skill card based on its current level.
+- **Embedded Links:** URLs included in any description field are now automatically converted into clickable hyperlinks, opening in a new tab.
+- **Data Migration:** The underlying data structure has been upgraded to support the new features. A migration process is in place to automatically and seamlessly update existing data stored in the browser's local storage to the new format.
+
+**2025-10-02 (Previous):**
 - **Vertical Tree View:** The tree view layout is now top-down and vertical for a more intuitive genealogical feel.
 - **Prerequisite Instancing:** Prerequisites are now properly "instanced," meaning they appear correctly under every skill that requires them.
 - **Default Expanded View:** The skill tree now loads with all branches expanded by default for a complete overview.

--- a/Xenophile/h-tree-view.css
+++ b/Xenophile/h-tree-view.css
@@ -1,0 +1,92 @@
+/* --- Horizontal Tree View Specific Styles --- */
+
+/* The main container for all the trees */
+.h-tree-container {
+    display: flex;
+    flex-direction: column; /* Each tree will be in its own row */
+    align-items: flex-start; /* Align trees to the left */
+    gap: 4rem; /* Space between different trees */
+    padding: 2rem;
+    overflow-x: auto; /* Allow horizontal scrolling if trees are wide */
+}
+
+/* A container for a single, complete tree (from root to leaves) */
+.h-tree-root {
+    display: inline-flex;
+    flex-direction: row; /* Key change: Root and children are side-by-side */
+    align-items: center; /* Center the root card and its children container vertically */
+}
+
+/* A group containing a single node and all its direct children */
+.h-tree-node-group {
+    display: flex;
+    flex-direction: row; /* Node is to the left, children to the right */
+    align-items: center; /* Center the card and the children container vertically */
+    position: relative;
+    margin: 1rem;
+}
+
+/* The container for the skill card itself */
+.h-tree-node {
+    flex-shrink: 0;
+}
+
+/* The container for all children of a node */
+.h-tree-children {
+    display: flex;
+    flex-direction: column; /* Key change: Children are stacked vertically */
+    justify-content: center; /* Center children vertically */
+    align-items: flex-start;
+    margin-left: 50px; /* Space between parent and children */
+    position: relative;
+}
+
+/* Hide children when collapsed */
+.h-tree-children.collapsed {
+    display: none;
+}
+
+
+/* --- SVG and Connector Lines --- */
+svg.h-connector-lines {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none; /* Allows clicking through the SVG layer */
+    z-index: 0; /* Behind the skill cards */
+}
+
+/* --- Toggle Button --- */
+.toggle-children-h {
+    position: absolute;
+    right: -12px; /* Position just beyond the card's right edge */
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1;
+    z-index: 2; /* Make sure button is on top */
+}
+
+.toggle-children-h::before {
+    display: block;
+}
+
+.toggle-children-h.collapsed::before {
+    content: '+';
+}
+
+.toggle-children-h:not(.collapsed)::before {
+    content: '−'; /* Using a proper minus sign */
+}

--- a/Xenophile/index.html
+++ b/Xenophile/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Xenophile</title>
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="tree-view.css" id="tree-view-stylesheet" disabled>
+    <link rel="stylesheet" href="tree-view.css" id="v-tree-stylesheet" disabled>
+    <link rel="stylesheet" href="h-tree-view.css" id="h-tree-stylesheet" disabled>
 </head>
 <body>
     <header>
@@ -16,7 +17,8 @@
         <div class="toolbar">
             <div class="view-switcher">
                 <button id="view-alpha-btn" class="view-btn active">Alphabetical</button>
-                <button id="view-tree-btn" class="view-btn">Tree</button>
+                <button id="view-vtree-btn" class="view-btn">V-Tree</button>
+                <button id="view-htree-btn" class="view-btn">H-Tree</button>
             </div>
             <div class="tree-controls" style="display: none;">
                 <button id="collapse-all-btn">Collapse All</button>
@@ -58,19 +60,47 @@
                     </label>
                 </div>
                 <div id="prerequisites-container">
-                    <div class="form-group">
-                        <label for="prerequisite1">Prerequisite 1:</label>
-                        <select id="prerequisite1" name="prerequisite1">
-                            <option value="">None</option>
-                        </select>
+                    <div class="prerequisite-item">
+                        <div class="form-group">
+                            <label for="prerequisite1">Prerequisite 1:</label>
+                            <select id="prerequisite1" name="prerequisite1">
+                                <option value="">None</option>
+                            </select>
+                        </div>
+                        <div class="form-group level-input">
+                             <label for="prereq1-level">Req. Lvl:</label>
+                            <input type="number" id="prereq1-level" name="prereq1-level" min="1" max="5" value="1">
+                        </div>
                     </div>
-                    <div class="form-group">
-                        <label for="prerequisite2">Prerequisite 2:</label>
-                        <select id="prerequisite2" name="prerequisite2">
-                            <option value="">None</option>
-                        </select>
+                     <div class="prerequisite-item">
+                        <div class="form-group">
+                            <label for="prerequisite2">Prerequisite 2:</label>
+                            <select id="prerequisite2" name="prerequisite2">
+                                <option value="">None</option>
+                            </select>
+                        </div>
+                        <div class="form-group level-input">
+                            <label for="prereq2-level">Req. Lvl:</label>
+                            <input type="number" id="prereq2-level" name="prereq2-level" min="1" max="5" value="1">
+                        </div>
                     </div>
                 </div>
+
+                <!-- Level Descriptions -->
+                <div id="level-descriptions-container">
+                    <h4>Level Descriptions (Optional)</h4>
+                    <div class="level-description-tabs">
+                        <button type="button" class="tab-btn active" data-tab="1">Lvl 1</button>
+                        <button type="button" class="tab-btn" data-tab="2">Lvl 2</button>
+                        <button type="button" class="tab-btn" data-tab="3">Lvl 3</button>
+                        <button type="button" class="tab-btn" data-tab="4">Lvl 4</button>
+                        <button type="button" class="tab-btn" data-tab="5">Lvl 5</button>
+                    </div>
+                    <div id="level-descriptions-content">
+                        <!-- Textareas will be dynamically generated here -->
+                    </div>
+                </div>
+
                 <button type="submit" id="save-btn">Save</button>
             </form>
         </div>

--- a/Xenophile/style.css
+++ b/Xenophile/style.css
@@ -122,12 +122,67 @@ main {
 
 .form-group input[type="text"],
 .form-group textarea,
-.form-group select {
+.form-group select,
+.form-group input[type="number"] {
     width: 100%;
     padding: 8px;
     border: 1px solid #ddd;
     border-radius: 4px;
     box-sizing: border-box; /* Important */
+}
+
+.prerequisite-item {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+}
+
+.prerequisite-item .form-group {
+    flex-grow: 1;
+}
+
+.prerequisite-item .level-input {
+    flex-grow: 0;
+    flex-basis: 100px;
+}
+
+/* Level Description Tabs */
+#level-descriptions-container {
+    margin-top: 1.5rem;
+    border-top: 1px solid #eee;
+    padding-top: 1rem;
+}
+
+.level-description-tabs {
+    display: flex;
+    margin-bottom: 0.5rem;
+}
+
+.tab-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ccc;
+    background-color: #f0f0f0;
+    cursor: pointer;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+    margin-right: 4px;
+}
+
+.tab-btn.active {
+    background-color: #fff;
+    border-bottom: 1px solid #fff;
+    position: relative;
+    top: 1px;
+}
+
+#level-descriptions-content textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    resize: vertical;
+    min-height: 80px;
 }
 
 button[type="submit"] {
@@ -208,8 +263,42 @@ button[type="submit"]:hover {
 }
 
 
+.card-title-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
 .skill-card h3 {
     margin-top: 0;
+    margin-bottom: 0;
+}
+
+.level-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.level-btn {
+    background-color: #e0e0e0;
+    border: 1px solid #ccc;
+    color: #333;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.level-btn:hover {
+    background-color: #d0d0d0;
+}
+
+.level-display {
+    font-weight: bold;
+    font-size: 0.9rem;
 }
 
 .skill-type {


### PR DESCRIPTION
This commit introduces a suite of new features to the Xenophile application, addressing multiple items from the user's to-do list.

Key features implemented:
- **Horizontal Tree View:** Added an "H-Tree" view mode for a left-to-right visualization of the skill tree, complementing the existing vertical "V-Tree" layout.
- **Skill Leveling System:** Implemented a 0-5 leveling system for skills and faculties. Users can now track and adjust their proficiency directly on each item's card.
- **Prerequisite Levels:** The data model has been upgraded to allow specifying a required level (1-5) for each prerequisite. The "Add/Edit" modal now includes UI for this.
- **Detailed Level Descriptions:** Added a tabbed interface in the modal for users to input unique descriptions for each of the 5 proficiency levels. The relevant description is displayed on the card based on its current level.
- **Embedded Links:** URLs in description fields are now automatically parsed and converted into clickable hyperlinks.
- **Data Migration:** A backward-compatible data migration function has been added to seamlessly upgrade data for existing users from localStorage.

The project's README has been updated to reflect these changes, including a new changelog entry and updated to-do list.