### PR TITLE
feat: Enhance forecast view with extended range and display options

### DIFF
--- a/PavementTemp/README.md
+++ b/PavementTemp/README.md
@@ -5,7 +5,7 @@ This is a simple web application designed to help pet owners determine if the pa
 ## Features
 
 *   **Advanced Temperature Model:** Calculates pavement temperature using a formula that incorporates air temperature, direct solar radiation, and wind speed for greater accuracy.
-*   **Hourly Forecast:** Displays a full-day, hour-by-hour forecast of air and pavement temperatures, complete with safety ratings, so you can plan your walks.
+*   **Extended Hourly Forecast:** Displays an hour-by-hour forecast starting from the current time and extending up to 30 hours into the future. The current hour is highlighted for easy reference, and you can use "Show More" / "Show Less" buttons to expand or collapse the view.
 *   **Interactive "Calculation Explorer":** Adjust the core weather values (air temp, solar radiation, wind speed) to see exactly how they impact the pavement temperature in real-time.
 *   **Location-Based:** Check temperatures by searching for a city or using your device's current location.
 *   **Clear Safety Indicators:** Color-coded messages show you at a glance if the pavement is safe, requires caution, or is dangerous.
@@ -13,12 +13,18 @@ This is a simple web application designed to help pet owners determine if the pa
 ## How to Use
 
 1.  **Enter a location:** Type a city name or click "Use My Location".
-2.  **Review the Forecast:** Check the current conditions and browse the hourly forecast to see how temperatures will change throughout the day.
+2.  **Review the Forecast:** Check the current conditions and browse the hourly forecast. The table starts at the current hour. Use the "Show More" button to see further into the future.
 3.  **Explore the Calculator:** Scroll down to the "Calculation Explorer" to experiment with the values and understand the science behind the estimates.
 
 ---
 
 ## Changelog
+
+**2025-10-04:**
+- **Enhanced Forecast View:**
+    - The forecast now includes data from the past 4 hours and extends up to 30 hours into the future, helping with trend analysis and planning.
+    - The current hour is now highlighted in the forecast grid for quick reference.
+    - Added "Show More" and "Show Less" buttons to control the number of forecast hours displayed (10, 20, or 30 hours). The user's preference is saved locally.
 
 **2025-10-03:**
 - **Major Feature Overhaul:**

--- a/PavementTemp/index.html
+++ b/PavementTemp/index.html
@@ -62,6 +62,10 @@
                     <!-- Rows will be populated by script.js -->
                 </tbody>
             </table>
+            <div class="forecast-controls">
+                <button id="showLessBtn" style="display: none;">Show Less</button>
+                <button id="showMoreBtn">Show More</button>
+            </div>
         </div>
     </div>
 

--- a/PavementTemp/style.css
+++ b/PavementTemp/style.css
@@ -144,6 +144,31 @@ h1 {
     background-color: #fdfdfd; /* Subtle zebra-striping for rows */
 }
 
+#forecast-table .current-hour {
+    background-color: #fff2ab; /* A gentle yellow highlight */
+    font-weight: bold;
+}
+
+.forecast-controls {
+    margin-top: 1em;
+    text-align: center;
+}
+
+.forecast-controls button {
+    padding: 8px 16px;
+    border-radius: 5px;
+    border: 1px solid #ff6347;
+    background-color: #fff;
+    color: #ff6347;
+    cursor: pointer;
+    margin: 0 5px;
+}
+
+.forecast-controls button:hover {
+    background-color: #ff6347;
+    color: white;
+}
+
 /* --- Responsive Design --- */
 @media (max-width: 820px) {
     .container, .info-container {

--- a/SunburnApp/README.md
+++ b/SunburnApp/README.md
@@ -1,4 +1,4 @@
-# Sunburn Safety
+# ☀️ Sunburn Safety ☀️
 
 A tool to check the UV index and estimate your time to sunburn for any location.
 
@@ -8,7 +8,7 @@ This tool provides a comprehensive, hourly forecast for sun exposure risk. It fe
 
 ## Features
 
-*   **Hourly UV Index Forecast:** Get a full-day, hour-by-hour breakdown of the UV index for your location.
+*   **Extended Hourly UV Index Forecast:** Get an hour-by-hour breakdown of the UV index, starting from the current time and extending up to 30 hours into the future. The current hour is highlighted, and you can expand or collapse the forecast with "Show More" / "Show Less" buttons.
 *   **Time-to-Burn Calculation:** Estimates how long you can be in the sun before getting a sunburn, personalized to one of six skin types.
 *   **Interactive "Calculation Explorer":** Instantly see how changes in the UV index or your selected skin type affect your estimated time to burn.
 *   **Location-Based:** Search for any city or use your device's current location for precise forecasts.
@@ -20,6 +20,12 @@ This tool fetches the hourly UV index forecast for your location. The time it ta
 ---
 
 ## Changelog
+
+**2025-10-04:**
+- **Enhanced Forecast View:**
+    - The forecast now includes data from the past 4 hours and extends up to 30 hours into the future, helping with trend analysis and planning.
+    - The current hour is now highlighted in the forecast grid for quick reference.
+    - Added "Show More" and "Show Less" buttons to control the number of forecast hours displayed (10, 20, or 30 hours). The user's preference is saved locally.
 
 **2025-10-03:**
 - **Major Feature Overhaul:**

--- a/SunburnApp/index.html
+++ b/SunburnApp/index.html
@@ -61,6 +61,10 @@
                     <!-- Rows will be populated by script.js -->
                 </tbody>
             </table>
+            <div class="forecast-controls">
+                <button id="showLessBtn" style="display: none;">Show Less</button>
+                <button id="showMoreBtn">Show More</button>
+            </div>
         </div>
     </div>
 

--- a/SunburnApp/style.css
+++ b/SunburnApp/style.css
@@ -144,6 +144,32 @@ h1 {
     background-color: #fdfdfd; /* Subtle zebra-striping for rows */
 }
 
+#forecast-table .current-hour {
+    background-color: #fff2ab; /* A gentle yellow highlight */
+    font-weight: bold;
+}
+
+.forecast-controls {
+    margin-top: 1em;
+    text-align: center;
+}
+
+.forecast-controls button {
+    padding: 8px 16px;
+    border-radius: 5px;
+    border: 1px solid #FFC300;
+    background-color: #fff;
+    color: #FFC300;
+    cursor: pointer;
+    margin: 0 5px;
+}
+
+.forecast-controls button:hover {
+    background-color: #FFC300;
+    color: white;
+}
+
+
 /* --- Responsive Design --- */
 @media (max-width: 820px) {
     .container, .info-container {


### PR DESCRIPTION
This commit introduces several enhancements to the forecast view for both the Pavement Temperature and Sunburn Risk applications.

Key changes include:
- Extended the forecast data range to include 4 hours of past data and up to 30 hours of future data.
- Highlighted the current hour in the forecast tables for easier reference.
- Implemented "Show More" and "Show Less" buttons to allow users to control the number of forecast hours displayed (10, 20, or 30).
- The user's preference for the number of displayed hours is now saved in `localStorage` for a persistent experience.
- Updated the README files for both applications to reflect the new functionality.