### PR TITLE
feat: Implement two-pane layout and Explorer view

### DIFF
--- a/Xenophile/index.html
+++ b/Xenophile/index.html
@@ -13,33 +13,53 @@
         <h1>Xenophile</h1>
         <p>Map your life's skill tree.</p>
     </header>
-    <main>
-        <div class="toolbar">
-            <div class="view-switcher">
-                <button id="view-alpha-btn" class="view-btn active">Alphabetical</button>
-                <button id="view-vtree-btn" class="view-btn">V-Tree</button>
-                <button id="view-htree-btn" class="view-btn">H-Tree</button>
+    <main id="app-container">
+        <!-- Left Pane: Search and Filter -->
+        <div id="left-pane">
+            <div class="pane-header">
+                <h2>Search & Filter</h2>
+                <button id="left-pane-toggle" class="pane-toggle-btn">&lt;</button>
             </div>
-            <div class="tree-controls" style="display: none;">
-                <button id="collapse-all-btn">Collapse All</button>
-                <button id="expand-all-btn">Expand All</button>
+            <div id="search-controls">
+                <input type="text" id="search-bar" placeholder="Search by name...">
+                <!-- Future filter controls will go here -->
             </div>
-            <div class="toolbar-group-right">
-                 <div class="discovery-mode-control">
-                    <label class="switch">
-                        <input type="checkbox" id="discovery-mode-toggle">
-                        <span class="slider round"></span>
-                    </label>
-                    <span class="discovery-label">Discovery Mode</span>
-                </div>
-                <input type="file" id="import-file-input" accept=".json" style="display: none;" />
-                <button id="import-btn" class="toolbar-btn">Import</button>
-                <button id="export-btn" class="toolbar-btn">Export</button>
-                <button id="add-skill-btn">Add New Item</button>
+            <div id="search-results-container">
+                <!-- Search results will be dynamically added here -->
             </div>
         </div>
-        <div id="skill-tree-container">
-            <!-- Skills will be rendered here -->
+
+        <!-- Right Pane: Main Content -->
+        <div id="right-pane">
+             <button id="right-pane-toggle" class="pane-toggle-btn" style="display: none;">&gt;</button>
+            <div class="toolbar">
+                <div id="view-switcher" class="view-switcher">
+                     <button id="view-explorer-btn" class="view-btn">Explorer</button>
+                    <button id="view-alpha-btn" class="view-btn active">Alphabetical</button>
+                    <button id="view-vtree-btn" class="view-btn">V-Tree</button>
+                    <button id="view-htree-btn" class="view-btn">H-Tree</button>
+                </div>
+                <div class="tree-controls" style="display: none;">
+                    <button id="collapse-all-btn">Collapse All</button>
+                    <button id="expand-all-btn">Expand All</button>
+                </div>
+                <div class="toolbar-group-right">
+                     <div class="discovery-mode-control">
+                        <label class="switch">
+                            <input type="checkbox" id="discovery-mode-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                        <span class="discovery-label">Discovery Mode</span>
+                    </div>
+                    <input type="file" id="import-file-input" accept=".json" style="display: none;" />
+                    <button id="import-btn" class="toolbar-btn">Import</button>
+                    <button id="export-btn" class="toolbar-btn">Export</button>
+                    <button id="add-skill-btn">Add New Item</button>
+                </div>
+            </div>
+            <div id="skill-tree-container">
+                <!-- Content (Explorer, Trees, List) will be rendered here -->
+            </div>
         </div>
     </main>
 

--- a/Xenophile/style.css
+++ b/Xenophile/style.css
@@ -490,3 +490,218 @@ input:checked + .slider:before {
 .show-details-link:hover {
     text-decoration: underline;
 }
+
+/* --- Two-Pane Layout --- */
+#app-container {
+    display: flex;
+    /* Adjust based on header height, which is roughly 60px + 1rem margin */
+    height: calc(100vh - 76px);
+}
+
+#left-pane, #right-pane {
+    display: flex;
+    flex-direction: column;
+    transition: width 0.3s ease, min-width 0.3s ease, height 0.3s ease;
+    position: relative;
+}
+
+#left-pane {
+    width: 350px;
+    min-width: 350px;
+    background-color: #f8f9fa;
+    border-right: 1px solid #dee2e6;
+    padding: 1rem;
+    overflow-y: auto;
+}
+
+#right-pane {
+    flex-grow: 1;
+    /* The toolbar and skill-tree-container are its flex children */
+}
+
+/* Pane Headers & Toggles */
+.pane-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.pane-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.pane-toggle-btn {
+    background: #e9ecef;
+    border: 1px solid #ced4da;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.pane-toggle-btn:hover {
+    background: #dee2e6;
+}
+
+/* Search Controls */
+#search-controls {
+    margin-bottom: 1rem;
+}
+
+#search-bar {
+    width: 100%;
+    padding: 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ced4da;
+    border-radius: 5px;
+    box-sizing: border-box;
+}
+
+#search-results-container {
+    flex-grow: 1;
+    overflow-y: auto;
+}
+
+/* --- Collapsed Pane States --- */
+#left-pane.collapsed {
+    width: 0;
+    min-width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    overflow: hidden;
+    border-right: none;
+}
+
+/* The toggle button to show the left pane when it's collapsed */
+#right-pane-toggle {
+    position: absolute;
+    left: 10px;
+    /* Align with the main toolbar's vertical position */
+    top: 1rem;
+    z-index: 10;
+}
+
+
+/* --- Responsive Design for Panes --- */
+@media (max-width: 768px) {
+    #app-container {
+        flex-direction: column;
+        height: auto; /* Let content define height */
+    }
+
+    #left-pane {
+        width: 100%;
+        box-sizing: border-box;
+        border-right: none;
+        border-bottom: 1px solid #dee2e6;
+        height: 40vh; /* Give it a fixed height on mobile */
+        min-height: 250px;
+    }
+
+    #left-pane.collapsed {
+        height: 50px; /* When collapsed on mobile, show just the header */
+        min-height: 50px;
+        overflow: hidden;
+    }
+
+    #left-pane.collapsed #search-controls,
+    #left-pane.collapsed #search-results-container {
+        display: none;
+    }
+
+    #left-pane-toggle {
+        /* Change icon for vertical toggle */
+        transform: rotate(90deg);
+    }
+    #left-pane.collapsed #left-pane-toggle {
+        transform: rotate(-90deg);
+    }
+
+    #right-pane {
+      height: 100vh; /* Take up the rest of the screen */
+    }
+}
+
+/* Adjust the right pane's main content container */
+#right-pane #skill-tree-container {
+    flex-grow: 1; /* Allow this to grow to fill space */
+    overflow-y: auto; /* Allow scrolling within the content area */
+}
+
+/* --- Explorer View Styles --- */
+.explorer-view-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem;
+    gap: 2rem;
+}
+
+.explorer-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.explorer-section-title {
+    color: #6c757d;
+    font-size: 1rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 0.5rem;
+    width: 100%;
+    text-align: center;
+}
+
+.explorer-items-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.explorer-card {
+    border: 1px solid #ced4da;
+    border-radius: 5px;
+    padding: 0.75rem 1rem;
+    background-color: #fff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    min-width: 150px;
+    text-align: center;
+}
+
+.explorer-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.08);
+    border-color: var(--skill-color);
+}
+
+.explorer-card .name {
+    font-weight: bold;
+    margin: 0;
+}
+
+.explorer-card .type {
+    font-size: 0.8rem;
+    color: #6c757d;
+}
+
+/* Style for the main, focal card */
+.explorer-focal .skill-card {
+    max-width: 600px;
+    margin: 0 auto; /* Center it */
+    border-width: 2px;
+    border-color: var(--skill-color);
+}


### PR DESCRIPTION
This commit introduces a major UI overhaul to the Xenophile application, focusing on a search-centric user experience.

Key changes:
- Restructures the main interface into a two-pane layout.
- The left pane is dedicated to search and filtering, with a live search bar that updates as the user types.
- The right pane contains the main content display and view switcher.
- Implements a new "Explorer" view that visualizes the relationships between skills. When an item is selected, it becomes the focal point, showing its prerequisites (parents) and dependents (children) as interactive cards.
- Adds responsive design for the panes to collapse on smaller screens, ensuring usability on mobile devices.
- Updates the application's JavaScript to manage the state and interactivity of the new UI components.